### PR TITLE
parse multiple options

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ into master on every `zig` release.
 * Supports both passing values using spacing and `=` (`-a 100`, `-a=100`)
   * Short args also support passing values with no spacing or `=` (`-a100`)
   * This all works with chaining (`-ba 100`, `-ba=100`, `-ba100`)
+* Supports options that can be specified multiple times (`-e 1 -e 2 -e 3`)
 * Print help message from parameter specification.
 * Parse help message to parameter specification.
 
@@ -33,10 +34,11 @@ pub fn main() !void {
     // First we specify what parameters our program can take.
     // We can use `parseParam` to parse a string to a `Param(Help)`
     const params = comptime [_]clap.Param(clap.Help){
-        clap.parseParam("-h, --help          Display this help and exit.              ") catch unreachable,
-        clap.parseParam("-n, --number <NUM>  An option parameter, which takes a value.") catch unreachable,
+        clap.parseParam("-h, --help             Display this help and exit.              ") catch unreachable,
+        clap.parseParam("-n, --number <NUM>     An option parameter, which takes a value.") catch unreachable,
+        clap.parseParam("-s, --string <STR>...  An option parameter which can be specified multiple times.") catch unreachable,
         clap.Param(clap.Help){
-            .takes_value = true,
+            .takes_value = .One,
         },
     };
 
@@ -46,15 +48,18 @@ pub fn main() !void {
     if (args.flag("--help"))
         debug.warn("--help\n", .{});
     if (args.option("--number")) |n|
-        debug.warn("--number = {}\n", .{ n });
+        debug.warn("--number = {}\n", .{n});
+    for (args.options("--string")) |s|
+        debug.warn("--string = {}\n", .{s});
     for (args.positionals()) |pos|
-        debug.warn("{}\n", .{ pos });
+        debug.warn("{}\n", .{pos});
 }
 
 ```
 
 The data structure returned has lookup speed on par with array access (`arr[i]`) and validates
-that the strings you pass to `option` and `flag` are actually parameters that the program can take:
+that the strings you pass to `option`, `options` and `flag` are actually parameters that the
+program can take:
 
 ```zig
 const std = @import("std");
@@ -106,10 +111,11 @@ pub fn main() !void {
     // First we specify what parameters our program can take.
     // We can use `parseParam` to parse a string to a `Param(Help)`
     const params = comptime [_]clap.Param(clap.Help){
-        clap.parseParam("-h, --help          Display this help and exit.              ") catch unreachable,
-        clap.parseParam("-n, --number <NUM>  An option parameter, which takes a value.") catch unreachable,
+        clap.parseParam("-h, --help             Display this help and exit.              ") catch unreachable,
+        clap.parseParam("-n, --number <NUM>     An option parameter, which takes a value.") catch unreachable,
+        clap.parseParam("-s, --string <STR>...  An option parameter which can be specified multiple times.") catch unreachable,
         clap.Param(clap.Help){
-            .takes_value = true,
+            .takes_value = .One,
         },
     };
 
@@ -125,9 +131,11 @@ pub fn main() !void {
     if (args.flag("--help"))
         debug.warn("--help\n", .{});
     if (args.option("--number")) |n|
-        debug.warn("--number = {}\n", .{ n });
+        debug.warn("--number = {}\n", .{n});
+    for (args.options("--string")) |s|
+        debug.warn("--string = {}\n", .{s});
     for (args.positionals()) |pos|
-        debug.warn("{}\n", .{ pos });
+        debug.warn("{}\n", .{pos});
 }
 
 ```
@@ -155,11 +163,11 @@ pub fn main() !void {
         clap.Param(u8){
             .id = 'n',
             .names = clap.Names{ .short = 'n', .long = "number" },
-            .takes_value = true,
+            .takes_value = .One,
         },
         clap.Param(u8){
             .id = 'f',
-            .takes_value = true,
+            .takes_value = .One,
         },
     };
 
@@ -179,12 +187,12 @@ pub fn main() !void {
         // arg.param will point to the parameter which matched the argument.
         switch (arg.param.id) {
             'h' => debug.warn("Help!\n", .{}),
-            'n' => debug.warn("--number = {}\n", .{ arg.value.? }),
+            'n' => debug.warn("--number = {}\n", .{arg.value.?}),
 
             // arg.value == null, if arg.param.takes_value == false.
             // Otherwise, arg.value is the value passed with the argument, such as "-a=10"
             // or "-a 10".
-            'f' => debug.warn("{}\n", .{ arg.value.? }),
+            'f' => debug.warn("{}\n", .{arg.value.?}),
             else => unreachable,
         }
     }

--- a/clap.zig
+++ b/clap.zig
@@ -25,6 +25,7 @@ pub const Names = struct {
     long: ?[]const u8 = null,
 };
 
+/// Whether a param takes no value (a flag), one value, or can be specified multiple times.
 pub const Values = enum {
     None,
     One,

--- a/clap.zig
+++ b/clap.zig
@@ -247,6 +247,10 @@ pub fn Args(comptime Id: type, comptime params: []const Param(Id)) type {
             return a.clap.option(name);
         }
 
+        pub fn allOptions(a: @This(), comptime name: []const u8) [][]const u8 {
+            return a.clap.allOptions(name);
+        }
+
         pub fn positionals(a: @This()) []const []const u8 {
             return a.clap.positionals();
         }

--- a/clap.zig
+++ b/clap.zig
@@ -277,8 +277,8 @@ pub fn Args(comptime Id: type, comptime params: []const Param(Id)) type {
             return a.clap.option(name);
         }
 
-        pub fn allOptions(a: @This(), comptime name: []const u8) [][]const u8 {
-            return a.clap.allOptions(name);
+        pub fn options(a: @This(), comptime name: []const u8) []const []const u8 {
+            return a.clap.options(name);
         }
 
         pub fn positionals(a: @This()) []const []const u8 {

--- a/clap/comptime.zig
+++ b/clap/comptime.zig
@@ -100,6 +100,15 @@ pub fn ComptimeClap(comptime Id: type, comptime params: []const clap.Param(Id)) 
             return parser.flags[param.id];
         }
 
+        pub fn option(parser: @This(), comptime name: []const u8) ?[]const u8 {
+            const param = comptime findParam(name);
+            if (param.takes_value == .None)
+                @compileError(name ++ " is a flag and not an option.");
+            if (param.takes_value == .Many)
+                @compileError(name ++ " takes many options, not one.");
+            return parser.single_options[param.id];
+        }
+
         pub fn options(parser: @This(), comptime name: []const u8) []const []const u8 {
             const param = comptime findParam(name);
             if (param.takes_value == .None)
@@ -108,15 +117,6 @@ pub fn ComptimeClap(comptime Id: type, comptime params: []const clap.Param(Id)) 
                 @compileError(name ++ " takes one option, not multiple.");
 
             return parser.multi_options[param.id];
-        }
-
-        pub fn option(parser: @This(), comptime name: []const u8) ?[]const u8 {
-            const param = comptime findParam(name);
-            if (param.takes_value == .None)
-                @compileError(name ++ " is a flag and not an option.");
-            if (param.takes_value == .Many)
-                @compileError(name ++ " takes many options, not one.");
-            return parser.single_options[param.id];
         }
 
         pub fn positionals(parser: @This()) []const []const u8 {

--- a/clap/comptime.zig
+++ b/clap/comptime.zig
@@ -39,7 +39,7 @@ pub fn ComptimeClap(comptime Id: type, comptime params: []const clap.Param(Id)) 
         allocator: *mem.Allocator,
 
         pub fn parse(allocator: *mem.Allocator, comptime ArgIter: type, iter: *ArgIter) !@This() {
-            var multis = [_]std.ArrayList([]const u8){undefined} ** single_options;
+            var multis = [_]std.ArrayList([]const u8){undefined} ** multi_options;
             for (multis) |*multi| {
                 multi.* = std.ArrayList([]const u8).init(allocator);
             }
@@ -64,13 +64,16 @@ pub fn ComptimeClap(comptime Id: type, comptime params: []const clap.Param(Id)) 
                     try pos.append(arg.value.?);
                 } else if (param.takes_value == .One) {
                     debug.assert(res.single_options.len != 0);
-                    res.single_options[param.id] = arg.value.?;
+                    if (res.single_options.len != 0)
+                        res.single_options[param.id] = arg.value.?;
                 } else if (param.takes_value == .Many) {
-                    debug.assert(res.multi_options.len != 0);
-                    try multis[param.id].append(arg.value.?);
+                    debug.assert(multis.len != 0);
+                    if (multis.len != 0)
+                        try multis[param.id].append(arg.value.?);
                 } else {
                     debug.assert(res.flags.len != 0);
-                    res.flags[param.id] = true;
+                    if (res.flags.len != 0)
+                        res.flags[param.id] = true;
                 }
             }
 

--- a/example/README.md.template
+++ b/example/README.md.template
@@ -14,6 +14,7 @@ into master on every `zig` release.
 * Supports both passing values using spacing and `=` (`-a 100`, `-a=100`)
   * Short args also support passing values with no spacing or `=` (`-a100`)
   * This all works with chaining (`-ba 100`, `-ba=100`, `-ba100`)
+* Supports options that can be specified multiple times (`-e 1 -e 2 -e 3`)
 * Print help message from parameter specification.
 * Parse help message to parameter specification.
 
@@ -28,7 +29,8 @@ The simplest way to use this library is to just call the `clap.parse` function.
 ```
 
 The data structure returned has lookup speed on par with array access (`arr[i]`) and validates
-that the strings you pass to `option` and `flag` are actually parameters that the program can take:
+that the strings you pass to `option`, `options` and `flag` are actually parameters that the
+program can take:
 
 ```zig
 {}

--- a/example/comptime-clap.zig
+++ b/example/comptime-clap.zig
@@ -9,10 +9,11 @@ pub fn main() !void {
     // First we specify what parameters our program can take.
     // We can use `parseParam` to parse a string to a `Param(Help)`
     const params = comptime [_]clap.Param(clap.Help){
-        clap.parseParam("-h, --help          Display this help and exit.              ") catch unreachable,
-        clap.parseParam("-n, --number <NUM>  An option parameter, which takes a value.") catch unreachable,
+        clap.parseParam("-h, --help             Display this help and exit.              ") catch unreachable,
+        clap.parseParam("-n, --number <NUM>     An option parameter, which takes a value.") catch unreachable,
+        clap.parseParam("-s, --string <STR>...  An option parameter which can be specified multiple times.") catch unreachable,
         clap.Param(clap.Help){
-            .takes_value = true,
+            .takes_value = .One,
         },
     };
 
@@ -29,6 +30,8 @@ pub fn main() !void {
         debug.warn("--help\n", .{});
     if (args.option("--number")) |n|
         debug.warn("--number = {}\n", .{n});
+    for (args.options("--string")) |s|
+        debug.warn("--string = {}\n", .{s});
     for (args.positionals()) |pos|
         debug.warn("{}\n", .{pos});
 }

--- a/example/simple.zig
+++ b/example/simple.zig
@@ -7,10 +7,11 @@ pub fn main() !void {
     // First we specify what parameters our program can take.
     // We can use `parseParam` to parse a string to a `Param(Help)`
     const params = comptime [_]clap.Param(clap.Help){
-        clap.parseParam("-h, --help          Display this help and exit.              ") catch unreachable,
-        clap.parseParam("-n, --number <NUM>  An option parameter, which takes a value.") catch unreachable,
+        clap.parseParam("-h, --help             Display this help and exit.              ") catch unreachable,
+        clap.parseParam("-n, --number <NUM>     An option parameter, which takes a value.") catch unreachable,
+        clap.parseParam("-s, --string <STR>...  An option parameter which can be specified multiple times.") catch unreachable,
         clap.Param(clap.Help){
-            .takes_value = true,
+            .takes_value = .One,
         },
     };
 
@@ -21,6 +22,8 @@ pub fn main() !void {
         debug.warn("--help\n", .{});
     if (args.option("--number")) |n|
         debug.warn("--number = {}\n", .{n});
+    for (args.options("--string")) |s|
+        debug.warn("--string = {}\n", .{s});
     for (args.positionals()) |pos|
         debug.warn("{}\n", .{pos});
 }

--- a/example/streaming-clap.zig
+++ b/example/streaming-clap.zig
@@ -15,11 +15,11 @@ pub fn main() !void {
         clap.Param(u8){
             .id = 'n',
             .names = clap.Names{ .short = 'n', .long = "number" },
-            .takes_value = true,
+            .takes_value = .One,
         },
         clap.Param(u8){
             .id = 'f',
-            .takes_value = true,
+            .takes_value = .One,
         },
     };
 


### PR DESCRIPTION
Hi again!

I'm proposing supporting multiple/repeated value-taking options. My use case is enabling extensions with a syntax like `-e, --extension <EXTENSION>` where the option can be specified multiple times to enable multiple extensions.

A sample implementation is attached which preserves the existing API while extending it to support multiple options. I use it like this:

```zig
    for (args.allOptions("--extension")) |extension|
        std.debug.print("enabling {}\n", .{extension});
```

We might want to make it explicitly opt-in (e.g. by requiring a declaration like `-e, --extension <EXTENSION>...`). What do you think?