### PR TITLE
Report error context in Diagnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ pub fn main() !void {
         },
     };
 
-    var args = try clap.parse(clap.Help, &params, std.heap.page_allocator);
+    var args = try clap.parse(clap.Help, &params, std.heap.page_allocator, null);
     defer args.deinit();
 
     if (args.flag("--help"))
@@ -118,6 +118,7 @@ pub fn main() !void {
             .takes_value = .One,
         },
     };
+    const Clap = clap.ComptimeClap(clap.Help, clap.args.OsIterator, &params);
 
     // We then initialize an argument iterator. We will use the OsIterator as it nicely
     // wraps iterating over arguments the most efficient way on each os.
@@ -125,7 +126,7 @@ pub fn main() !void {
     defer iter.deinit();
 
     // Parse the arguments
-    var args = try clap.ComptimeClap(clap.Help, &params).parse(allocator, clap.args.OsIterator, &iter);
+    var args = try Clap.parse(allocator, &iter, null);
     defer args.deinit();
 
     if (args.flag("--help"))
@@ -183,7 +184,7 @@ pub fn main() !void {
     };
 
     // Because we use a streaming parser, we have to consume each argument parsed individually.
-    while (try parser.next()) |arg| {
+    while (try parser.next(null)) |arg| {
         // arg.param will point to the parameter which matched the argument.
         switch (arg.param.id) {
             'h' => debug.warn("Help!\n", .{}),

--- a/README.md
+++ b/README.md
@@ -42,7 +42,16 @@ pub fn main() !void {
         },
     };
 
-    var args = try clap.parse(clap.Help, &params, std.heap.page_allocator, null);
+    // Initalize our diagnostics, which can be used for reporting useful errors.
+    // This is optional. You can also just pass `null` to `parser.next` if you
+    // don't care about the extra information `Diagnostics` provides.
+    var diag: clap.Diagnostic = undefined;
+
+    var args = clap.parse(clap.Help, &params, std.heap.page_allocator, &diag) catch |err| {
+        // Report useful error and exit
+        diag.report(std.io.getStdErr().outStream(), err) catch {};
+        return err;
+    };
     defer args.deinit();
 
     if (args.flag("--help"))
@@ -66,13 +75,11 @@ const std = @import("std");
 const clap = @import("clap");
 
 pub fn main() !void {
-    // First we specify what parameters our program can take.
-    // We can use `parseParam` to parse a string to a `Param(Help)`
     const params = comptime [_]clap.Param(clap.Help){
         clap.parseParam("-h, --help  Display this help and exit.") catch unreachable,
     };
 
-    var args = try clap.parse(clap.Help, &params, std.heap.direct_allocator);
+    var args = try clap.parse(clap.Help, &params, std.heap.direct_allocator, null);
     defer args.deinit();
 
     _ = args.flag("--helps");
@@ -125,8 +132,17 @@ pub fn main() !void {
     var iter = try clap.args.OsIterator.init(allocator);
     defer iter.deinit();
 
+    // Initalize our diagnostics, which can be used for reporting useful errors.
+    // This is optional. You can also just pass `null` to `parser.next` if you
+    // don't care about the extra information `Diagnostics` provides.
+    var diag: clap.Diagnostic = undefined;
+
     // Parse the arguments
-    var args = try Clap.parse(allocator, &iter, null);
+    var args = Clap.parse(allocator, &iter, &diag) catch |err| {
+        // Report useful error and exit
+        diag.report(std.io.getStdErr().outStream(), err) catch {};
+        return err;
+    };
     defer args.deinit();
 
     if (args.flag("--help"))
@@ -183,8 +199,17 @@ pub fn main() !void {
         .iter = &iter,
     };
 
+    // Initalize our diagnostics, which can be used for reporting useful errors.
+    // This is optional. You can also just pass `null` to `parser.next` if you
+    // don't care about the extra information `Diagnostics` provides.
+    var diag: clap.Diagnostic = undefined;
+
     // Because we use a streaming parser, we have to consume each argument parsed individually.
-    while (try parser.next(null)) |arg| {
+    while (parser.next(&diag) catch |err| {
+        // Report useful error and exit
+        diag.report(std.io.getStdErr().outStream(), err) catch {};
+        return err;
+    }) |arg| {
         // arg.param will point to the parameter which matched the argument.
         switch (arg.param.id) {
             'h' => debug.warn("Help!\n", .{}),

--- a/clap/streaming.zig
+++ b/clap/streaming.zig
@@ -62,14 +62,15 @@ pub fn StreamingClap(comptime Id: type, comptime ArgIterator: type) type {
 
                     const arg = arg_info.arg;
                     const kind = arg_info.kind;
-                    const eql_index = mem.indexOfScalar(u8, arg, '=');
 
                     switch (kind) {
                         .long => {
+                            const eql_index = mem.indexOfScalar(u8, arg, '=');
+                            const name = if (eql_index) |i| arg[0..i] else arg;
+                            const maybe_value = if (eql_index) |i| arg[i + 1 ..] else null;
+
                             for (parser.params) |*param| {
                                 const match = param.names.long orelse continue;
-                                const name = if (eql_index) |i| arg[0..i] else arg;
-                                const maybe_value = if (eql_index) |i| arg[i + 1 ..] else null;
 
                                 if (!mem.eql(u8, name, match))
                                     continue;

--- a/example/comptime-clap.zig
+++ b/example/comptime-clap.zig
@@ -16,6 +16,7 @@ pub fn main() !void {
             .takes_value = .One,
         },
     };
+    const Clap = clap.ComptimeClap(clap.Help, clap.args.OsIterator, &params);
 
     // We then initialize an argument iterator. We will use the OsIterator as it nicely
     // wraps iterating over arguments the most efficient way on each os.
@@ -23,7 +24,7 @@ pub fn main() !void {
     defer iter.deinit();
 
     // Parse the arguments
-    var args = try clap.ComptimeClap(clap.Help, &params).parse(allocator, clap.args.OsIterator, &iter);
+    var args = try Clap.parse(allocator, &iter, null);
     defer args.deinit();
 
     if (args.flag("--help"))

--- a/example/comptime-clap.zig
+++ b/example/comptime-clap.zig
@@ -23,8 +23,17 @@ pub fn main() !void {
     var iter = try clap.args.OsIterator.init(allocator);
     defer iter.deinit();
 
+    // Initalize our diagnostics, which can be used for reporting useful errors.
+    // This is optional. You can also just pass `null` to `parser.next` if you
+    // don't care about the extra information `Diagnostics` provides.
+    var diag: clap.Diagnostic = undefined;
+
     // Parse the arguments
-    var args = try Clap.parse(allocator, &iter, null);
+    var args = Clap.parse(allocator, &iter, &diag) catch |err| {
+        // Report useful error and exit
+        diag.report(std.io.getStdErr().outStream(), err) catch {};
+        return err;
+    };
     defer args.deinit();
 
     if (args.flag("--help"))

--- a/example/simple-error.zig
+++ b/example/simple-error.zig
@@ -2,13 +2,11 @@ const std = @import("std");
 const clap = @import("clap");
 
 pub fn main() !void {
-    // First we specify what parameters our program can take.
-    // We can use `parseParam` to parse a string to a `Param(Help)`
     const params = comptime [_]clap.Param(clap.Help){
         clap.parseParam("-h, --help  Display this help and exit.") catch unreachable,
     };
 
-    var args = try clap.parse(clap.Help, &params, std.heap.direct_allocator);
+    var args = try clap.parse(clap.Help, &params, std.heap.direct_allocator, null);
     defer args.deinit();
 
     _ = args.flag("--helps");

--- a/example/simple.zig
+++ b/example/simple.zig
@@ -15,7 +15,7 @@ pub fn main() !void {
         },
     };
 
-    var args = try clap.parse(clap.Help, &params, std.heap.page_allocator);
+    var args = try clap.parse(clap.Help, &params, std.heap.page_allocator, null);
     defer args.deinit();
 
     if (args.flag("--help"))

--- a/example/simple.zig
+++ b/example/simple.zig
@@ -15,7 +15,16 @@ pub fn main() !void {
         },
     };
 
-    var args = try clap.parse(clap.Help, &params, std.heap.page_allocator, null);
+    // Initalize our diagnostics, which can be used for reporting useful errors.
+    // This is optional. You can also just pass `null` to `parser.next` if you
+    // don't care about the extra information `Diagnostics` provides.
+    var diag: clap.Diagnostic = undefined;
+
+    var args = clap.parse(clap.Help, &params, std.heap.page_allocator, &diag) catch |err| {
+        // Report useful error and exit
+        diag.report(std.io.getStdErr().outStream(), err) catch {};
+        return err;
+    };
     defer args.deinit();
 
     if (args.flag("--help"))

--- a/example/streaming-clap.zig
+++ b/example/streaming-clap.zig
@@ -34,8 +34,17 @@ pub fn main() !void {
         .iter = &iter,
     };
 
+    // Initalize our diagnostics, which can be used for reporting useful errors.
+    // This is optional. You can also just pass `null` to `parser.next` if you
+    // don't care about the extra information `Diagnostics` provides.
+    var diag: clap.Diagnostic = undefined;
+
     // Because we use a streaming parser, we have to consume each argument parsed individually.
-    while (try parser.next(null)) |arg| {
+    while (parser.next(&diag) catch |err| {
+        // Report useful error and exit
+        diag.report(std.io.getStdErr().outStream(), err) catch {};
+        return err;
+    }) |arg| {
         // arg.param will point to the parameter which matched the argument.
         switch (arg.param.id) {
             'h' => debug.warn("Help!\n", .{}),

--- a/example/streaming-clap.zig
+++ b/example/streaming-clap.zig
@@ -35,7 +35,7 @@ pub fn main() !void {
     };
 
     // Because we use a streaming parser, we have to consume each argument parsed individually.
-    while (try parser.next()) |arg| {
+    while (try parser.next(null)) |arg| {
         // arg.param will point to the parameter which matched the argument.
         switch (arg.param.id) {
             'h' => debug.warn("Help!\n", .{}),


### PR DESCRIPTION
This is the work that will close #6. Right now the new `Diagnostic` struct only contains a `Names` struct that will either contain the `param.names` in cases where there was an error parsing a specific parameter, or the name of an argument in case the argument doesn't match any parameter. I'll need to also create a function on `Diagnostic` called `report` that will be the default way of reporting a parsing error to a stream.