### PR TITLE
zig master updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ pub fn main() !void {
 
     var args = clap.parse(clap.Help, &params, std.heap.page_allocator, &diag) catch |err| {
         // Report useful error and exit
-        diag.report(std.io.getStdErr().outStream(), err) catch {};
+        diag.report(std.io.getStdErr().writer(), err) catch {};
         return err;
     };
     defer args.deinit();
@@ -151,7 +151,7 @@ pub fn main() !void {
     // Because we use a streaming parser, we have to consume each argument parsed individually.
     while (parser.next(&diag) catch |err| {
         // Report useful error and exit
-        diag.report(std.io.getStdErr().outStream(), err) catch {};
+        diag.report(std.io.getStdErr().writer(), err) catch {};
         return err;
     }) |arg| {
         // arg.param will point to the parameter which matched the argument.
@@ -184,7 +184,7 @@ const clap = @import("clap");
 
 pub fn main() !void {
     const stderr_file = std.io.getStdErr();
-    var stderr_out_stream = stderr_file.outStream();
+    var stderr_out_stream = stderr_file.writer();
 
     // clap.help is a function that can print a simple help message, given a
     // slice of Param(Help). There is also a helpEx, which can print a
@@ -224,7 +224,7 @@ const std = @import("std");
 const clap = @import("clap");
 
 pub fn main() !void {
-    const stderr = std.io.getStdErr().outStream();
+    const stderr = std.io.getStdErr().writer();
 
     // clap.usage is a function that can print a simple usage message, given a
     // slice of Param(Help). There is also a usageEx, which can print a

--- a/build.zig
+++ b/build.zig
@@ -66,7 +66,7 @@ fn readMeStep(b: *Builder) *std.build.Step {
         fn make(step: *std.build.Step) anyerror!void {
             @setEvalBranchQuota(10000);
             const file = try std.fs.cwd().createFile("README.md", .{});
-            const stream = &file.outStream();
+            const stream = &file.writer();
             try stream.print(@embedFile("example/README.md.template"), .{
                 @embedFile("example/simple.zig"),
                 @embedFile("example/simple-error.zig"),

--- a/clap/streaming.zig
+++ b/clap/streaming.zig
@@ -234,7 +234,7 @@ fn testErr(params: []const clap.Param(u8), args_strings: []const []const u8, exp
     while (c.next(&diag) catch |err| {
         var buf: [1024]u8 = undefined;
         var slice_stream = io.fixedBufferStream(&buf);
-        diag.report(slice_stream.outStream(), err) catch unreachable;
+        diag.report(slice_stream.writer(), err) catch unreachable;
         testing.expectEqualStrings(expected, slice_stream.getWritten());
         return;
     }) |_| {}

--- a/example/help.zig
+++ b/example/help.zig
@@ -3,7 +3,7 @@ const clap = @import("clap");
 
 pub fn main() !void {
     const stderr_file = std.io.getStdErr();
-    var stderr_out_stream = stderr_file.outStream();
+    var stderr_out_stream = stderr_file.writer();
 
     // clap.help is a function that can print a simple help message, given a
     // slice of Param(Help). There is also a helpEx, which can print a

--- a/example/simple-ex.zig
+++ b/example/simple-ex.zig
@@ -27,7 +27,7 @@ pub fn main() !void {
 
     var args = clap.parseEx(clap.Help, &params, allocator, &iter, &diag) catch |err| {
         // Report useful error and exit
-        diag.report(std.io.getStdErr().outStream(), err) catch {};
+        diag.report(std.io.getStdErr().writer(), err) catch {};
         return err;
     };
     defer args.deinit();

--- a/example/simple.zig
+++ b/example/simple.zig
@@ -20,7 +20,7 @@ pub fn main() !void {
 
     var args = clap.parse(clap.Help, &params, std.heap.page_allocator, &diag) catch |err| {
         // Report useful error and exit
-        diag.report(std.io.getStdErr().outStream(), err) catch {};
+        diag.report(std.io.getStdErr().writer(), err) catch {};
         return err;
     };
     defer args.deinit();

--- a/example/streaming-clap.zig
+++ b/example/streaming-clap.zig
@@ -42,7 +42,7 @@ pub fn main() !void {
     // Because we use a streaming parser, we have to consume each argument parsed individually.
     while (parser.next(&diag) catch |err| {
         // Report useful error and exit
-        diag.report(std.io.getStdErr().outStream(), err) catch {};
+        diag.report(std.io.getStdErr().writer(), err) catch {};
         return err;
     }) |arg| {
         // arg.param will point to the parameter which matched the argument.

--- a/example/usage.zig
+++ b/example/usage.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const clap = @import("clap");
 
 pub fn main() !void {
-    const stderr = std.io.getStdErr().outStream();
+    const stderr = std.io.getStdErr().writer();
 
     // clap.usage is a function that can print a simple usage message, given a
     // slice of Param(Help). There is also a usageEx, which can print a


### PR DESCRIPTION
`outStream`s deprecated for `writer`s, and now `{s}` is required to format `[]u8` as a string.