### PR TITLE
Refactor Diagnostic (and others) into a ParseOption struct

### DIFF
--- a/example/simple-ex.zig
+++ b/example/simple-ex.zig
@@ -1,5 +1,5 @@
-const std = @import("std");
 const clap = @import("clap");
+const std = @import("std");
 
 const debug = std.debug;
 
@@ -21,11 +21,13 @@ pub fn main() !void {
     defer iter.deinit();
 
     // Initalize our diagnostics, which can be used for reporting useful errors.
-    // This is optional. You can also just pass `null` to `parser.next` if you
-    // don't care about the extra information `Diagnostics` provides.
-    var diag: clap.Diagnostic = undefined;
-
-    var args = clap.parseEx(clap.Help, &params, allocator, &iter, &diag) catch |err| {
+    // This is optional. You can also pass `.{}` to `clap.parse` if you don't
+    // care about the extra information `Diagnostics` provides.
+    var diag = clap.Diagnostic{};
+    var args = clap.parseEx(clap.Help, &params, &iter, .{
+        .allocator = allocator,
+        .diagnostic = &diag,
+    }) catch |err| {
         // Report useful error and exit
         diag.report(std.io.getStdErr().outStream(), err) catch {};
         return err;

--- a/example/simple.zig
+++ b/example/simple.zig
@@ -1,5 +1,5 @@
-const std = @import("std");
 const clap = @import("clap");
+const std = @import("std");
 
 const debug = std.debug;
 
@@ -14,11 +14,10 @@ pub fn main() !void {
     };
 
     // Initalize our diagnostics, which can be used for reporting useful errors.
-    // This is optional. You can also just pass `null` to `parser.next` if you
-    // don't care about the extra information `Diagnostics` provides.
-    var diag: clap.Diagnostic = undefined;
-
-    var args = clap.parse(clap.Help, &params, std.heap.page_allocator, &diag) catch |err| {
+    // This is optional. You can also pass `.{}` to `clap.parse` if you don't
+    // care about the extra information `Diagnostics` provides.
+    var diag = clap.Diagnostic{};
+    var args = clap.parse(clap.Help, &params, .{ .diagnostic = &diag }) catch |err| {
         // Report useful error and exit
         diag.report(std.io.getStdErr().outStream(), err) catch {};
         return err;

--- a/example/streaming-clap.zig
+++ b/example/streaming-clap.zig
@@ -1,5 +1,5 @@
-const std = @import("std");
 const clap = @import("clap");
+const std = @import("std");
 
 const debug = std.debug;
 
@@ -28,19 +28,18 @@ pub fn main() !void {
     var iter = try clap.args.OsIterator.init(allocator);
     defer iter.deinit();
 
-    // Initialize our streaming parser.
+    // Initalize our diagnostics, which can be used for reporting useful errors.
+    // This is optional. You can also leave the `diagnostic` field unset if you
+    // don't care about the extra information `Diagnostic` provides.
+    var diag = clap.Diagnostic{};
     var parser = clap.StreamingClap(u8, clap.args.OsIterator){
         .params = &params,
         .iter = &iter,
+        .diagnostic = &diag,
     };
 
-    // Initalize our diagnostics, which can be used for reporting useful errors.
-    // This is optional. You can also just pass `null` to `parser.next` if you
-    // don't care about the extra information `Diagnostics` provides.
-    var diag: clap.Diagnostic = undefined;
-
     // Because we use a streaming parser, we have to consume each argument parsed individually.
-    while (parser.next(&diag) catch |err| {
+    while (parser.next() catch |err| {
         // Report useful error and exit
         diag.report(std.io.getStdErr().outStream(), err) catch {};
         return err;


### PR DESCRIPTION
This allows for default arguments, which we can also extend without
breaking peoples code in the future. This is a breaking change right now
though.