### PR TITLE
Update example of `usage`

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,9 +224,9 @@ pub fn main() !void {
     try clap.usage(
         std.io.getStdErr().writer(),
         comptime &.{
-            clap.parseParam("-h, --help       Display this help and exit.         ") catch unreachable,
-            clap.parseParam("-v, --version    Output version information and exit.") catch unreachable,
-            clap.parseParam("    --value <N>  Output version information and exit.") catch unreachable,
+            clap.parseParam("-h, --help       Display this help and exit.              ") catch unreachable,
+            clap.parseParam("-v, --version    Output version information and exit.     ") catch unreachable,
+            clap.parseParam("    --value <N>  An option parameter, which takes a value.") catch unreachable,
         },
     );
 }

--- a/example/usage.zig
+++ b/example/usage.zig
@@ -8,9 +8,9 @@ pub fn main() !void {
     try clap.usage(
         std.io.getStdErr().writer(),
         comptime &.{
-            clap.parseParam("-h, --help       Display this help and exit.         ") catch unreachable,
-            clap.parseParam("-v, --version    Output version information and exit.") catch unreachable,
-            clap.parseParam("    --value <N>  Output version information and exit.") catch unreachable,
+            clap.parseParam("-h, --help       Display this help and exit.              ") catch unreachable,
+            clap.parseParam("-v, --version    Output version information and exit.     ") catch unreachable,
+            clap.parseParam("    --value <N>  An option parameter, which takes a value.") catch unreachable,
         },
     );
 }


### PR DESCRIPTION
There was a small typo in the `usage` example that listed two params as "version"