### PR TITLE
Update zig-master branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
           submodules: recursive
       - uses: goto-bus-stop/setup-zig@v1.3.0
         with:
-          version: 0.8.0
+          version: master
       - run: zig build
   lint:
     runs-on: ubuntu-latest
@@ -20,5 +20,5 @@ jobs:
       - uses: actions/checkout@v2.3.4
       - uses: goto-bus-stop/setup-zig@v1.3.0
         with:
-          version: 0.8.0
+          version: master
       - run: zig fmt --check .

--- a/clap/comptime.zig
+++ b/clap/comptime.zig
@@ -195,7 +195,7 @@ fn testErr(
 ) !void {
     var diag = clap.Diagnostic{};
     var iter = clap.args.SliceIterator{ .args = args_strings };
-    var args = clap.parseEx(u8, params, &iter, .{
+    _ = clap.parseEx(u8, params, &iter, .{
         .allocator = testing.allocator,
         .diagnostic = &diag,
     }) catch |err| {


### PR DESCRIPTION
This PR is meant to implement #47 since it seems inactive and is merging into the wrong branch. All this does is discard an unused variable since those are compiler errors now. I also went ahead and changed the `zig-master` CI to use `master` instead of `0.8.0`. If the latter change wasn't wanted I can go ahead and revert it.