### PR TITLE
Update calls to tokenizer

### DIFF
--- a/clap.zig
+++ b/clap.zig
@@ -74,7 +74,7 @@ pub fn parseParam(line: []const u8) !Param(Help) {
     @setEvalBranchQuota(std.math.maxInt(u32));
 
     var found_comma = false;
-    var it = mem.tokenize(line, " \t");
+    var it = mem.tokenize(u8, line, " \t");
     var param_str = it.next() orelse return error.NoParamFound;
 
     const short_name = if (!mem.startsWith(u8, param_str, "--") and


### PR DESCRIPTION
The tokenize function was made generic, so we have to pass the type as
the first parameter.