### PR TITLE
Fix deprecated builtin usage

### DIFF
--- a/clap/args.zig
+++ b/clap/args.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
 
-const builtin = std.builtin;
+const builtin = @import("builtin");
 const debug = std.debug;
 const heap = std.heap;
 const mem = std.mem;


### PR DESCRIPTION
`@import("builtin")` should be used instead of `std.builtin`.