### PR TITLE
Improve help and usage examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,21 +180,25 @@ const clap = @import("clap");
 const std = @import("std");
 
 pub fn main() !void {
+    const params = comptime [_]clap.Param(clap.Help){
+        clap.parseParam("-h, --help     Display this help and exit.         ") catch unreachable,
+        clap.parseParam("-v, --version  Output version information and exit.") catch unreachable,
+    };
+
+    var args = try clap.parse(clap.Help, &params, .{});
+    defer args.deinit();
+
     // clap.help is a function that can print a simple help message, given a
     // slice of Param(Help). There is also a helpEx, which can print a
     // help message for any Param, but it is more verbose to call.
-    try clap.help(
-        std.io.getStdErr().writer(),
-        comptime &.{
-            clap.parseParam("-h, --help     Display this help and exit.         ") catch unreachable,
-            clap.parseParam("-v, --version  Output version information and exit.") catch unreachable,
-        },
-    );
+    if (args.flag("--help"))
+        return clap.help(std.io.getStdErr().writer(), &params);
 }
 
 ```
 
 ```
+$ zig-out/bin/help --help
 	-h, --help   	Display this help and exit.
 	-v, --version	Output version information and exit.
 ```
@@ -218,22 +222,26 @@ const clap = @import("clap");
 const std = @import("std");
 
 pub fn main() !void {
+    const params = comptime [_]clap.Param(clap.Help){
+        clap.parseParam("-h, --help       Display this help and exit.              ") catch unreachable,
+        clap.parseParam("-v, --version    Output version information and exit.     ") catch unreachable,
+        clap.parseParam("    --value <N>  An option parameter, which takes a value.") catch unreachable,
+    };
+
+    var args = try clap.parse(clap.Help, &params, .{});
+    defer args.deinit();
+
     // clap.usage is a function that can print a simple usage message, given a
     // slice of Param(Help). There is also a usageEx, which can print a
     // usage message for any Param, but it is more verbose to call.
-    try clap.usage(
-        std.io.getStdErr().writer(),
-        comptime &.{
-            clap.parseParam("-h, --help       Display this help and exit.              ") catch unreachable,
-            clap.parseParam("-v, --version    Output version information and exit.     ") catch unreachable,
-            clap.parseParam("    --value <N>  An option parameter, which takes a value.") catch unreachable,
-        },
-    );
+    if (args.flag("--help"))
+        return clap.usage(std.io.getStdErr().writer(), &params);
 }
 
 ```
 
 ```
+$ zig-out/bin/usage --help
 [-hv] [--value <N>]
 ```
 

--- a/example/README.md.template
+++ b/example/README.md.template
@@ -74,6 +74,7 @@ program can take.
 ```
 
 ```
+$ zig-out/bin/help --help
 	-h, --help   	Display this help and exit.
 	-v, --version	Output version information and exit.
 ```
@@ -97,6 +98,7 @@ of the help message.
 ```
 
 ```
+$ zig-out/bin/usage --help
 [-hv] [--value <N>]
 ```
 

--- a/example/help.zig
+++ b/example/help.zig
@@ -2,14 +2,17 @@ const clap = @import("clap");
 const std = @import("std");
 
 pub fn main() !void {
+    const params = comptime [_]clap.Param(clap.Help){
+        clap.parseParam("-h, --help     Display this help and exit.         ") catch unreachable,
+        clap.parseParam("-v, --version  Output version information and exit.") catch unreachable,
+    };
+
+    var args = try clap.parse(clap.Help, &params, .{});
+    defer args.deinit();
+
     // clap.help is a function that can print a simple help message, given a
     // slice of Param(Help). There is also a helpEx, which can print a
     // help message for any Param, but it is more verbose to call.
-    try clap.help(
-        std.io.getStdErr().writer(),
-        comptime &.{
-            clap.parseParam("-h, --help     Display this help and exit.         ") catch unreachable,
-            clap.parseParam("-v, --version  Output version information and exit.") catch unreachable,
-        },
-    );
+    if (args.flag("--help"))
+        return clap.help(std.io.getStdErr().writer(), &params);
 }

--- a/example/usage.zig
+++ b/example/usage.zig
@@ -2,15 +2,18 @@ const clap = @import("clap");
 const std = @import("std");
 
 pub fn main() !void {
+    const params = comptime [_]clap.Param(clap.Help){
+        clap.parseParam("-h, --help       Display this help and exit.              ") catch unreachable,
+        clap.parseParam("-v, --version    Output version information and exit.     ") catch unreachable,
+        clap.parseParam("    --value <N>  An option parameter, which takes a value.") catch unreachable,
+    };
+
+    var args = try clap.parse(clap.Help, &params, .{});
+    defer args.deinit();
+
     // clap.usage is a function that can print a simple usage message, given a
     // slice of Param(Help). There is also a usageEx, which can print a
     // usage message for any Param, but it is more verbose to call.
-    try clap.usage(
-        std.io.getStdErr().writer(),
-        comptime &.{
-            clap.parseParam("-h, --help       Display this help and exit.              ") catch unreachable,
-            clap.parseParam("-v, --version    Output version information and exit.     ") catch unreachable,
-            clap.parseParam("    --value <N>  An option parameter, which takes a value.") catch unreachable,
-        },
-    );
+    if (args.flag("--help"))
+        return clap.usage(std.io.getStdErr().writer(), &params);
 }


### PR DESCRIPTION
Instead of just calling these function, have the examples be small
programs that demonstrates how you would actually use them together with
argument parsing.

fixes #57