### PR TITLE
OsIterator - Fix compilation error on windows

### DIFF
--- a/clap/args.zig
+++ b/clap/args.zig
@@ -73,7 +73,7 @@ pub const OsIterator = struct {
 
     pub fn next(iter: *OsIterator) Error!?[:0]const u8 {
         if (builtin.os.tag == .windows) {
-            return (try iter.args.next(iter.arena.allocator())) orelse return null;
+            return try (iter.args.next(iter.arena.allocator()) orelse return null);
         } else {
             return iter.args.nextPosix();
         }


### PR DESCRIPTION
Hi @Hejsil,

I found a compilation error on windows when trying to build [gyro](https://github.com/mattnite/gyro).

The error can be reproduced when building the examples: maybe they should be run on the CI too.

Have a nice day :)