### PR TITLE
New `help` api that provides options as to how paramters are printed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,8 @@ is generated at runtime.
 
 The `help` prints a simple list of all parameters the program can take. It expects the
 `Id` to have a `description` method and an `value` method so that it can provide that
-in the output.
+in the output. `HelpOptions` is passed to `help` to control how the help message is
+printed.
 
 ```zig
 const clap = @import("clap");
@@ -220,15 +221,18 @@ pub fn main() !void {
     // slice of Param(Help). There is also a helpEx, which can print a
     // help message for any Param, but it is more verbose to call.
     if (res.args.help)
-        return clap.help(std.io.getStdErr().writer(), clap.Help, &params);
+        return clap.help(std.io.getStdErr().writer(), clap.Help, &params, .{});
 }
 
 ```
 
 ```
 $ zig-out/bin/help --help
-	-h, --help   	Display this help and exit.
-	-v, --version	Output version information and exit.
+    -h, --help
+            Display this help and exit.
+
+    -v, --version
+            Output version information and exit.
 ```
 
 ### `usage`

--- a/example/README.md.template
+++ b/example/README.md.template
@@ -58,7 +58,8 @@ is generated at runtime.
 
 The `help` prints a simple list of all parameters the program can take. It expects the
 `Id` to have a `description` method and an `value` method so that it can provide that
-in the output.
+in the output. `HelpOptions` is passed to `help` to control how the help message is
+printed.
 
 ```zig
 {s}
@@ -66,8 +67,11 @@ in the output.
 
 ```
 $ zig-out/bin/help --help
-	-h, --help   	Display this help and exit.
-	-v, --version	Output version information and exit.
+    -h, --help
+            Display this help and exit.
+
+    -v, --version
+            Output version information and exit.
 ```
 
 ### `usage`

--- a/example/help.zig
+++ b/example/help.zig
@@ -15,5 +15,5 @@ pub fn main() !void {
     // slice of Param(Help). There is also a helpEx, which can print a
     // help message for any Param, but it is more verbose to call.
     if (res.args.help)
-        return clap.help(std.io.getStdErr().writer(), clap.Help, &params);
+        return clap.help(std.io.getStdErr().writer(), clap.Help, &params, .{});
 }


### PR DESCRIPTION
New `help` function that is significantly more powerful and should be extendable without any more breaking changes to it. By default, this function supports a markdown like format where input newlines are only respected in some cases. This can be turned off to make `help` respect all newlines in the descriptions if desired.

Max width is also supported, which solves #28 (however, the caller needs to figure out the width of the tty).