### PR TITLE
use builtin.Type instead of deprecated builtin.TypeInfo

### DIFF
--- a/clap.zig
+++ b/clap.zig
@@ -895,7 +895,7 @@ fn Arguments(
     comptime value_parsers: anytype,
     comptime multi_arg_kind: MultiArgKind,
 ) type {
-    var fields: [params.len]builtin.TypeInfo.StructField = undefined;
+    var fields: [params.len]builtin.Type.StructField = undefined;
 
     var i: usize = 0;
     for (params) |param| {


### PR DESCRIPTION
Syncs with latest zig master version 0.10.0-dev.4117+54854e2ab