### PR TITLE
build: expose 'clap' module for dependeees

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -4,6 +4,9 @@ pub fn build(b: *std.Build) void {
     const optimize = b.standardOptimizeOption(.{});
     const target = b.standardTargetOptions(.{});
 
+    const clap_mod = b.createModule(.{ .source_file = .{ .path = "clap.zig" } });
+    b.modules.put(b.dupe("clap"), clap_mod) catch @panic("OOM");
+
     const test_step = b.step("test", "Run all tests in all modes.");
     const tests = b.addTest(.{
         .root_source_file = .{ .path = "clap.zig" },

--- a/build.zig
+++ b/build.zig
@@ -4,8 +4,7 @@ pub fn build(b: *std.Build) void {
     const optimize = b.standardOptimizeOption(.{});
     const target = b.standardTargetOptions(.{});
 
-    const clap_mod = b.createModule(.{ .source_file = .{ .path = "clap.zig" } });
-    b.modules.put(b.dupe("clap"), clap_mod) catch @panic("OOM");
+    const clap_mod = b.addModule("clap", .{ .source_file = .{ .path = "clap.zig" } });
 
     const test_step = b.step("test", "Run all tests in all modes.");
     const tests = b.addTest(.{

--- a/build.zig
+++ b/build.zig
@@ -4,7 +4,7 @@ pub fn build(b: *std.Build) void {
     const optimize = b.standardOptimizeOption(.{});
     const target = b.standardTargetOptions(.{});
 
-    const clap_mod = b.addModule("clap", .{ .source_file = .{ .path = "clap.zig" } });
+    b.addModule(.{ .name = "clap", .source_file = .{ .path = "clap.zig" } });
 
     const test_step = b.step("test", "Run all tests in all modes.");
     const tests = b.addTest(.{


### PR DESCRIPTION
With this change i was able to use clap with the new package manager.

In my package's build.zig:
```diff
diff --git a/build.zig b/build.zig
index 93e123d..54a38d6 100644
--- a/build.zig
+++ b/build.zig
+    const zig_clap_pkg = b.dependency("clap", .{
+        .target = target,
+        .optimize = optimize,
+    });
+    const zig_clap = zig_clap_pkg.module("clap");
     const exe = b.addExecutable(.{ ... });
+    exe.addModule("zig-clap", zig_clap);
```
Note: before this patch, this change ^ resulted in an error. Something like 'can't find module clap'.

and my package's build.zig.zon:
```console
$ zig version
0.11.0-dev.1796+c9e02d3e6

$ cat build.zig.zon 
.{
    .name = "mylib",
    .version = "0.0.1",

    .dependencies = .{
        .clap = .{
            .url = "https://github.com/travisstaloch/zig-clap/archive/refs/heads/master.tar.gz",
            .hash = "1220caf0689cafa7d546ef413f1c1cc5a278dfa1aa2e4de437d3ccee7527bf8e68cd",
        },
    }
}
```

I hope this is the correct way to do this.  I haven't used the package manager much other than this.  I got the idea from felix' similar repo: https://github.com/MasterQ32/zig-args/blob/master/build.zig#L7 .  But i wanted to use the  `usage()/help()` methods clap provides. 