### PR TITLE
Update to latest zig (4d7dd1689)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -29,7 +29,7 @@ pub fn build(b: *std.Build) void {
             .target = target,
             .optimize = optimize,
         });
-        const install_example = b.addInstallArtifact(example);
+        const install_example = b.addInstallArtifact(example, .{});
         example.addModule("clap", clap_mod);
         example_step.dependOn(&example.step);
         example_step.dependOn(&install_example.step);


### PR DESCRIPTION
This makes a single change to the build.zig file to support zig 0.11.0-dev.4407+4d7dd1689, std.Build.addInstallArtifact() now takes a options struct which specifies where to put artifacts but the defaults are the same as before the change.