### PR TITLE
Add required an default value support

### DIFF
--- a/clap/parsers.zig
+++ b/clap/parsers.zig
@@ -4,6 +4,7 @@ const fmt = std.fmt;
 const testing = std.testing;
 
 pub const default = .{
+    .bool = boolean,
     .string = string,
     .str = string,
     .u8 = int(u8, 0),
@@ -27,6 +28,24 @@ pub fn string(in: []const u8) error{}![]const u8 {
 
 test "string" {
     try testing.expectEqualStrings("aa", try string("aa"));
+}
+
+/// Parse boolean value. False, off and 0 considered false, everything else is true.
+pub fn boolean(in: []const u8) error{ParameterTooLong}!bool {
+    // check if input is not too long
+    const MAX_LEN = 16;
+    if (in.len >= MAX_LEN) return error.ParameterTooLong;
+
+    // convert to lowercase
+    var lower: [MAX_LEN]u8 = undefined;
+    for (in, 0..) |c, i| {
+        lower[i] = std.ascii.toLower(c);
+    }
+
+    if (std.mem.eql(u8, "0", lower[0..in.len]) or
+        std.mem.eql(u8, "off", lower[0..in.len]) or
+        std.mem.eql(u8, "false", lower[0..in.len])) return false;
+    return true;
 }
 
 /// A parser that uses `std.fmt.parseInt` to parse the string into an integer value.


### PR DESCRIPTION
This is not ready yet, I just push it for reference.

Tasks:
- [x] add required/optional support to the parser
- [x] add default value support to the parser
- [ ] add more tests for various required/optional cases
- [ ] give error, when a required parameter is missing (eg. -m is mandatory)
- [ ] also check if the provided parameter type is correct (it should be done already)
- [ ] make sure that optional value is a `?value` and the required is just `value`
- [ ] add `bool` for supporting on/off switches
- [ ] handle the case when bool is `0/off/false` as off and everything else as on
- [ ] set the default value when there is no parameter provided
- [ ] fix the commit messages before asking for a merge

Closes #82 