### PR TITLE
Add autodoc website

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,47 @@
+name: API Reference
+
+on:
+  push:
+    branches: [master]
+
+  # Allow manually starting the workflow.
+  workflow_dispatch:
+
+# If two concurrent runs are started,
+# prefer the latest one.
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+
+  build:
+    name: Build website
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: goto-bus-stop/setup-zig@v2.0.1
+      with:
+        version: master
+    - name: Build
+      run: zig build docs
+    - name: Upload
+      uses: actions/upload-pages-artifact@v2
+      with:
+        path: "zig-out/docs/"
+
+  publish:
+    name: Publish website
+    runs-on: ubuntu-latest
+    needs: build  # wait for build to finish
+    permissions:
+      # Request sufficient permissions to publish the website.
+      pages: write
+      id-token: write
+    steps:
+    - name: Deploy to GitHub Pages
+      id: deployment
+      uses: actions/deploy-pages@v3
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}

--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ in the release notes.
 * Print help message from parameter specification.
 * Parse help message to parameter specification.
 
+## API Reference
+
+Automatically generated API Reference for the project
+can be found at https://Hejsil.github.io/zig-clap.
+Note that Zig autodoc is in beta; the website may be broken or incomplete.
+
 ## Examples
 
 ### `clap.parse`

--- a/build.zig
+++ b/build.zig
@@ -35,6 +35,14 @@ pub fn build(b: *std.Build) void {
         example_step.dependOn(&install_example.step);
     }
 
+    const docs_step = b.step("docs", "Generate docs.");
+    const install_docs = b.addInstallDirectory(.{
+        .source_dir = tests.getEmittedDocs(),
+        .install_dir = .prefix,
+        .install_subdir = "docs",
+    });
+    docs_step.dependOn(&install_docs.step);
+
     const readme_step = b.step("readme", "Remake README.");
     const readme = readMeStep(b);
     readme.dependOn(example_step);


### PR DESCRIPTION
If this is not something you'd like for clap to provide,
feel free to close the PR--it didn't require a lot of effort.

A preview of the output is available at https://abhinav.github.io/zig-clap/.

---

This adds a `zig build docs` step that builds the documentation website
and writes it to zig-out/docs.

It further includes a GitHub Workflow that publishes this website
to GitHub Pages. The GitHub Workflow is divided into two jobs:

- build: builds the documentation and uploads it
- publish: downloads the documentation and publishes it

These are separate jobs to minimize permissions available
to the build job.

This workflow runs on two events:

- after every push to master
- workflow_dispatch: this allows manually running the workflow
  from its *Actions* page if something went wrong

The instructions to do this came from the following sources:

- https://sudw1n.gitlab.io/posts/zig-build-docs/
  provided instructions on how to build autodocs with Zig master.
- ziglibs/ansi-term#20 was used as reference for the GitHub Workflow.

---

**Important pre-merge steps:**

If this PR is accepted, the following steps should be taken
before merging the PR:

1. Go to **Settings** for the repository
2. Select **Pages** on the left under *Code and automation*
3. Under *Build and deployment* set **Source** to **GitHub Actions**
4. Merge the PR.

If the steps are missed, the PR will merge just fine,
but the docs job will fail immediately on merge.
This can be remedied by following steps 1-3 above,
and either adding a new commit on master,
or manually firing the workflow from the Actions > API Reference page.
