### PR TITLE
Fix bug in the README sample code

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ pub fn main() !void {
         std.debug.print("--number = {}\n", .{n});
     for (res.args.string) |s|
         std.debug.print("--string = {s}\n", .{s});
-    for (res.positionals[0]) |pos|
+    for (res.positionals) |pos|
         std.debug.print("{s}\n", .{pos});
 }
 


### PR DESCRIPTION
There was a small typo in the sample code where `res.positionals` was typed as `res.positionals[0]`.