### PR TITLE
fix: compiler error zig v0.14.0-dev.2577+271452d22

### DIFF
--- a/clap.zig
+++ b/clap.zig
@@ -904,7 +904,7 @@ fn Positionals(
         fields[i] = .{
             .name = std.fmt.comptimePrint("{}", .{i}),
             .type = FieldT,
-            .default_value_ptr = null,
+            .default_value = null,
             .is_comptime = false,
             .alignment = @alignOf(FieldT),
         };
@@ -1022,7 +1022,7 @@ fn Arguments(
         fields[i] = .{
             .name = name,
             .type = @TypeOf(default_value),
-            .default_value_ptr = @ptrCast(&default_value),
+            .default_value = @ptrCast(&default_value),
             .is_comptime = false,
             .alignment = @alignOf(@TypeOf(default_value)),
         };


### PR DESCRIPTION
This fixes a compiler error for the latest zig master (v0.14.0-dev.2577+271452d22) where `std.builtin.Type.StructField` `default_value_ptr` has been renamed to `default_value.`

All tests are passing. 