### PR TITLE
fix build.zig.zon package name

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,5 +1,5 @@
 .{
-    .name = .clap,
+    .name = "clap",
     .version = "0.10.0",
     .minimum_zig_version = "0.14.0",
     .fingerprint = 0x65f99e6f07a316a0,


### PR DESCRIPTION
It seem that commit  `13c0daa` broke the build.zig.zon by replacing the name of the package.
