### PR TITLE
Changed .name to string in build.zig.zon

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,5 +1,5 @@
 .{
-    .name = .clap,
+    .name = "clap",
     .version = "0.10.0",
     .minimum_zig_version = "0.14.0",
     .fingerprint = 0x65f99e6f07a316a0,


### PR DESCRIPTION
I am new to Zig but I'm fairly certain that .name should still be a string. I think a mistake happened in the commit to version 0.9.1.

https://github.com/Hejsil/zig-clap/commit/13c0daa5276fba9ae4f81a0e839733b068126dc8#diff-12dc677c49af0bd162081512eac1adca6ec6040095aeaaa59cb9f931abccefc9R2
