### PR TITLE
fix: Use the new @Struct and @Tuple constructors

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .name = .clap,
     .version = "0.11.0",
-    .minimum_zig_version = "0.15.1",
+    .minimum_zig_version = "0.16.0-dev.1484+d0ba6642b",
     .fingerprint = 0x65f99e6f07a316a0,
     .paths = .{
         "clap",


### PR DESCRIPTION
`@Type` has been replaced with individual type-creating builtins in zig master, see:
- [https://codeberg.org/ziglang/zig/commit/c5383173a0de17210f3036acd942738e906997e5](https://codeberg.org/ziglang/zig/commit/c5383173a0de17210f3036acd942738e906997e5)
- [https://codeberg.org/ziglang/zig/commit/dec1163fbb892f276179ae74b51007c656157d99](https://codeberg.org/ziglang/zig/commit/dec1163fbb892f276179ae74b51007c656157d99)

This PR uses the new `@Struct` and `@Tuple` builtins where `@Type` was used previously.