### PR TITLE
fix: Update deprecated APIs for Zig 0.16.0-dev.1859+212968c57

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .name = .clap,
     .version = "0.11.0",
-    .minimum_zig_version = "0.16.0-dev.1484+d0ba6642b",
+    .minimum_zig_version = "0.16.0-dev.1859+212968c57",
     .fingerprint = 0x65f99e6f07a316a0,
     .paths = .{
         "clap",

--- a/clap.zig
+++ b/clap.zig
@@ -562,9 +562,9 @@ pub const Diagnostic = struct {
     }
 
     /// Wrapper around `report`, which writes to a file in a buffered manner
-    pub fn reportToFile(diag: Diagnostic, file: std.fs.File, err: anyerror) !void {
+    pub fn reportToFile(diag: Diagnostic, io: std.Io, file: std.Io.File, err: anyerror) !void {
         var buf: [1024]u8 = undefined;
-        var writer = file.writer(&buf);
+        var writer = file.writer(io, &buf);
         try diag.report(&writer.interface, err);
         return writer.interface.flush();
     }
@@ -1358,13 +1358,14 @@ pub const HelpOptions = struct {
 
 /// Wrapper around `help`, which writes to a file in a buffered manner
 pub fn helpToFile(
-    file: std.fs.File,
+    io: std.Io,
+    file: std.Io.File,
     comptime Id: type,
     params: []const Param(Id),
     opt: HelpOptions,
 ) !void {
     var buf: [1024]u8 = undefined;
-    var writer = file.writer(&buf);
+    var writer = file.writer(io, &buf);
     try help(&writer.interface, Id, params, opt);
     return writer.interface.flush();
 }
@@ -2017,9 +2018,9 @@ test "clap.help" {
 }
 
 /// Wrapper around `usage`, which writes to a file in a buffered manner
-pub fn usageToFile(file: std.fs.File, comptime Id: type, params: []const Param(Id)) !void {
+pub fn usageToFile(io: std.Io, file: std.Io.File, comptime Id: type, params: []const Param(Id)) !void {
     var buf: [1024]u8 = undefined;
-    var writer = file.writer(&buf);
+    var writer = file.writer(io, &buf);
     try usage(&writer.interface, Id, params);
     return writer.interface.flush();
 }

--- a/clap.zig
+++ b/clap.zig
@@ -116,7 +116,7 @@ fn countParams(str: []const u8) usize {
     var res: usize = 0;
     var it = std.mem.splitScalar(u8, str, '\n');
     while (it.next()) |line| {
-        const trimmed = std.mem.trimLeft(u8, line, " \t");
+        const trimmed = std.mem.trimStart(u8, line, " \t");
         if (std.mem.startsWith(u8, trimmed, "-") or
             std.mem.startsWith(u8, trimmed, "<"))
         {
@@ -1426,7 +1426,7 @@ pub fn help(
             var res: usize = std.math.maxInt(usize);
             var it = std.mem.tokenizeScalar(u8, description, '\n');
             while (it.next()) |line| : (first_line = false) {
-                const trimmed = std.mem.trimLeft(u8, line, " ");
+                const trimmed = std.mem.trimStart(u8, line, " ");
                 const indent = line.len - trimmed.len;
 
                 // If the first line has no indentation, then we ignore the indentation of the
@@ -1460,7 +1460,7 @@ pub fn help(
             else
                 raw_line[@min(min_description_indent, raw_line.len)..];
 
-            const line = std.mem.trimLeft(u8, indented_line, " ");
+            const line = std.mem.trimStart(u8, indented_line, " ");
             if (line.len == 0) {
                 non_emitted_newlines += 1;
                 continue;

--- a/example/help.zig
+++ b/example/help.zig
@@ -13,12 +13,14 @@ pub fn main() !void {
     });
     defer res.deinit();
 
+    var threaded: std.Io.Threaded = .init_single_threaded;
+    const io: std.Io = threaded.io();
     // `clap.help` is a function that can print a simple help message. It can print any `Param`
     // where `Id` has a `description` and `value` method (`Param(Help)` is one such parameter).
     // The last argument contains options as to how `help` should print those parameters. Using
     // `.{}` means the default options.
     if (res.args.help != 0)
-        return clap.helpToFile(.stderr(), clap.Help, &params, .{});
+        return clap.helpToFile(io, .stderr(), clap.Help, &params, .{});
 }
 
 const clap = @import("clap");

--- a/example/simple-ex.zig
+++ b/example/simple-ex.zig
@@ -23,6 +23,9 @@ pub fn main() !void {
         .ANSWER = clap.parsers.enumeration(YesNo),
     };
 
+    var threaded: std.Io.Threaded = .init_single_threaded;
+    const io: std.Io = threaded.io();
+
     var diag = clap.Diagnostic{};
     var res = clap.parse(clap.Help, &params, parsers, .{
         .diagnostic = &diag,
@@ -32,7 +35,7 @@ pub fn main() !void {
         .assignment_separators = "=:",
     }) catch |err| {
         // Report useful error and exit.
-        try diag.reportToFile(.stderr(), err);
+        try diag.reportToFile(io, .stderr(), err);
         return err;
     };
     defer res.deinit();

--- a/example/simple.zig
+++ b/example/simple.zig
@@ -16,12 +16,14 @@ pub fn main() !void {
     // This is optional. You can also pass `.{}` to `clap.parse` if you don't
     // care about the extra information `Diagnostics` provides.
     var diag = clap.Diagnostic{};
+    var threaded: std.Io.Threaded = .init_single_threaded;
+    const io: std.Io = threaded.io();
     var res = clap.parse(clap.Help, &params, clap.parsers.default, .{
         .diagnostic = &diag,
         .allocator = gpa.allocator(),
     }) catch |err| {
         // Report useful error and exit.
-        try diag.reportToFile(.stderr(), err);
+        try diag.reportToFile(io, .stderr(), err);
         return err;
     };
     defer res.deinit();

--- a/example/streaming-clap.zig
+++ b/example/streaming-clap.zig
@@ -31,10 +31,13 @@ pub fn main() !void {
         .diagnostic = &diag,
     };
 
+    var threaded: std.Io.Threaded = .init_single_threaded;
+    const io: std.Io = threaded.io();
+
     // Because we use a streaming parser, we have to consume each argument parsed individually.
     while (parser.next() catch |err| {
         // Report useful error and exit.
-        try diag.reportToFile(.stderr(), err);
+        try diag.reportToFile(io, .stderr(), err);
         return err;
     }) |arg| {
         // arg.param will point to the parameter which matched the argument.

--- a/example/subcommands.zig
+++ b/example/subcommands.zig
@@ -29,6 +29,9 @@ pub fn main() !void {
 
     _ = iter.next();
 
+    var threaded: std.Io.Threaded = .init_single_threaded;
+    const io: std.Io = threaded.io();
+
     var diag = clap.Diagnostic{};
     var res = clap.parseEx(clap.Help, &main_params, main_parsers, &iter, .{
         .diagnostic = &diag,
@@ -41,7 +44,7 @@ pub fn main() !void {
         // not fully consumed. It can then be reused to parse the arguments for subcommands.
         .terminating_positional = 0,
     }) catch |err| {
-        try diag.reportToFile(.stderr(), err);
+        try diag.reportToFile(io, .stderr(), err);
         return err;
     };
     defer res.deinit();
@@ -73,11 +76,13 @@ fn mathMain(gpa: std.mem.Allocator, iter: *std.process.ArgIterator, main_args: M
 
     // Here we pass the partially parsed argument iterator.
     var diag = clap.Diagnostic{};
+    var threaded: std.Io.Threaded = .init_single_threaded;
+    const io: std.Io = threaded.io();
     var res = clap.parseEx(clap.Help, &params, clap.parsers.default, iter, .{
         .diagnostic = &diag,
         .allocator = gpa,
     }) catch |err| {
-        try diag.reportToFile(.stderr(), err);
+        try diag.reportToFile(io, .stderr(), err);
         return err; // propagate error
     };
     defer res.deinit();

--- a/example/usage.zig
+++ b/example/usage.zig
@@ -14,10 +14,13 @@ pub fn main() !void {
     });
     defer res.deinit();
 
+    var threaded: std.Io.Threaded = .init_single_threaded;
+    const io: std.Io = threaded.io();
+
     // `clap.usageToFile` is a function that can print a simple usage string. It can print any
     // `Param` where `Id` has a `value` method (`Param(Help)` is one such parameter).
     if (res.args.help != 0)
-        return clap.usageToFile(.stdout(), clap.Help, &params);
+        return clap.usageToFile(io, .stdout(), clap.Help, &params);
 }
 
 const clap = @import("clap");


### PR DESCRIPTION
 ## Summary

  - Replace deprecated `std.mem.trimLeft` with `std.mem.trimStart`
  - Replace deprecated `std.fs.File` with `std.Io.File` and update function signatures accordingly

   ## Breaking Changes

  The following functions have updated signatures due to the `std.fs.File` to `std.Io.File` migration:

  - `reportToFile`
  - `helpToFile`
  - `usageToFile`

  Each function now requires a new `io: std.Io` parameter as the first argument, and the `file` parameter type has changed from `std.fs.File` to `std.Io.File`.
