### PR TITLE
fix: use new `std.process.Init` args for Zig `0.16.0-dev.2261+d6b3dd25a`

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ incomplete.
 The simplest way to use this library is to just call the `clap.parse` function.
 
 ```zig
-pub fn main() !void {
+pub fn main(init: std.process.Init) !void {
     var gpa_state = std.heap.DebugAllocator(.{}){};
     const gpa = gpa_state.allocator();
     defer _ = gpa_state.deinit();
@@ -76,7 +76,7 @@ pub fn main() !void {
     // This is optional. You can also pass `.{}` to `clap.parse` if you don't
     // care about the extra information `Diagnostics` provides.
     var diag = clap.Diagnostic{};
-    var res = clap.parse(clap.Help, &params, clap.parsers.default, .{
+    var res = clap.parse(clap.Help, &params, clap.parsers.default, init.minimal.args, .{
         .diagnostic = &diag,
         .allocator = gpa,
     }) catch |err| {
@@ -112,7 +112,7 @@ contains a parser that returns `usize`. You can pass in something other than `cl
 if you want some other mapping.
 
 ```zig
-pub fn main() !void {
+pub fn main(init: std.process.Init) !void {
     var gpa_state = std.heap.DebugAllocator(.{}){};
     const gpa = gpa_state.allocator();
     defer _ = gpa_state.deinit();
@@ -142,7 +142,7 @@ pub fn main() !void {
     };
 
     var diag = clap.Diagnostic{};
-    var res = clap.parse(clap.Help, &params, parsers, .{
+    var res = clap.parse(clap.Help, &params, parsers, init.minimal.args, .{
         .diagnostic = &diag,
         .allocator = gpa,
         // The assignment separator can be configured. `--number=1` and `--number:1` is now
@@ -198,7 +198,7 @@ const main_params = clap.parseParamsComptime(
 // get the return type of `clap.parse` and `clap.parseEx`.
 const MainArgs = clap.ResultEx(clap.Help, &main_params, main_parsers);
 
-pub fn main() !void {
+pub fn main(init: std.process.Init) !void {
     var gpa_state = std.heap.DebugAllocator(.{}){};
     const gpa = gpa_state.allocator();
     defer _ = gpa_state.deinit();
@@ -206,7 +206,7 @@ pub fn main() !void {
     var threaded: std.Io.Threaded = .init_single_threaded;
     const io: std.Io = threaded.io();
 
-    var iter = try std.process.ArgIterator.initWithAllocator(gpa);
+    var iter = try init.minimal.args.iterateAllocator(gpa);
     defer iter.deinit();
 
     _ = iter.next();
@@ -238,7 +238,7 @@ pub fn main() !void {
     }
 }
 
-fn mathMain(io: std.Io, gpa: std.mem.Allocator, iter: *std.process.ArgIterator, main_args: MainArgs) !void {
+fn mathMain(io: std.Io, gpa: std.mem.Allocator, iter: *std.process.Args.Iterator, main_args: MainArgs) !void {
     // The parent arguments are not used here, but there are cases where it might be useful, so
     // this example shows how to pass the arguments around.
     _ = main_args;
@@ -284,7 +284,7 @@ The `streaming.Clap` is the base of all the other parsers. It's a streaming pars
 `args.Iterator` to provide it with arguments lazily.
 
 ```zig
-pub fn main() !void {
+pub fn main(init: std.process.Init) !void {
     var gpa_state = std.heap.DebugAllocator(.{}){};
     const gpa = gpa_state.allocator();
     defer _ = gpa_state.deinit();
@@ -306,7 +306,7 @@ pub fn main() !void {
         .{ .id = 'f', .takes_value = .one },
     };
 
-    var iter = try std.process.ArgIterator.initWithAllocator(gpa);
+    var iter = try init.minimal.args.iterateAllocator(gpa);
     defer iter.deinit();
 
     // Skip exe argument.
@@ -316,7 +316,7 @@ pub fn main() !void {
     // This is optional. You can also leave the `diagnostic` field unset if you
     // don't care about the extra information `Diagnostic` provides.
     var diag = clap.Diagnostic{};
-    var parser = clap.streaming.Clap(u8, std.process.ArgIterator){
+    var parser = clap.streaming.Clap(u8, std.process.Args.Iterator){
         .params = &params,
         .iter = &iter,
         .diagnostic = &diag,
@@ -363,7 +363,7 @@ runtime.
 is passed to `help` to control how the help message is printed.
 
 ```zig
-pub fn main() !void {
+pub fn main(init: std.process.Init) !void {
     var gpa_state = std.heap.DebugAllocator(.{}){};
     const gpa = gpa_state.allocator();
     defer _ = gpa_state.deinit();
@@ -377,7 +377,7 @@ pub fn main() !void {
         \\
     );
 
-    var res = try clap.parse(clap.Help, &params, clap.parsers.default, .{ .allocator = gpa });
+    var res = try clap.parse(clap.Help, &params, clap.parsers.default, init.minimal.args, .{ .allocator = gpa });
     defer res.deinit();
 
     // `clap.help` is a function that can print a simple help message. It can print any `Param`
@@ -407,7 +407,7 @@ $ zig-out/bin/help --help
 `value` method so it can provide that in the output.
 
 ```zig
-pub fn main() !void {
+pub fn main(init: std.process.Init) !void {
     var gpa_state = std.heap.DebugAllocator(.{}){};
     const gpa = gpa_state.allocator();
     defer _ = gpa_state.deinit();
@@ -422,7 +422,7 @@ pub fn main() !void {
         \\
     );
 
-    var res = try clap.parse(clap.Help, &params, clap.parsers.default, .{ .allocator = gpa });
+    var res = try clap.parse(clap.Help, &params, clap.parsers.default, init.minimal.args, .{ .allocator = gpa });
     defer res.deinit();
 
     // `clap.usageToFile` is a function that can print a simple usage string. It can print any

--- a/README.md
+++ b/README.md
@@ -55,13 +55,6 @@ The simplest way to use this library is to just call the `clap.parse` function.
 
 ```zig
 pub fn main(init: std.process.Init) !void {
-    var gpa_state = std.heap.DebugAllocator(.{}){};
-    const gpa = gpa_state.allocator();
-    defer _ = gpa_state.deinit();
-
-    var threaded: std.Io.Threaded = .init_single_threaded;
-    const io: std.Io = threaded.io();
-
     // First we specify what parameters our program can take.
     // We can use `parseParamsComptime` to parse a string into an array of `Param(Help)`.
     const params = comptime clap.parseParamsComptime(
@@ -78,10 +71,10 @@ pub fn main(init: std.process.Init) !void {
     var diag = clap.Diagnostic{};
     var res = clap.parse(clap.Help, &params, clap.parsers.default, init.minimal.args, .{
         .diagnostic = &diag,
-        .allocator = gpa,
+        .allocator = init.gpa,
     }) catch |err| {
         // Report useful error and exit.
-        try diag.reportToFile(io, .stderr(), err);
+        try diag.reportToFile(init.io, .stderr(), err);
         return err;
     };
     defer res.deinit();
@@ -113,13 +106,6 @@ if you want some other mapping.
 
 ```zig
 pub fn main(init: std.process.Init) !void {
-    var gpa_state = std.heap.DebugAllocator(.{}){};
-    const gpa = gpa_state.allocator();
-    defer _ = gpa_state.deinit();
-
-    var threaded: std.Io.Threaded = .init_single_threaded;
-    const io: std.Io = threaded.io();
-
     // First we specify what parameters our program can take.
     // We can use `parseParamsComptime` to parse a string into an array of `Param(Help)`.
     const params = comptime clap.parseParamsComptime(
@@ -144,13 +130,13 @@ pub fn main(init: std.process.Init) !void {
     var diag = clap.Diagnostic{};
     var res = clap.parse(clap.Help, &params, parsers, init.minimal.args, .{
         .diagnostic = &diag,
-        .allocator = gpa,
+        .allocator = init.gpa,
         // The assignment separator can be configured. `--number=1` and `--number:1` is now
         // allowed.
         .assignment_separators = "=:",
     }) catch |err| {
         // Report useful error and exit.
-        try diag.reportToFile(io, .stderr(), err);
+        try diag.reportToFile(init.io, .stderr(), err);
         return err;
     };
     defer res.deinit();
@@ -199,14 +185,7 @@ const main_params = clap.parseParamsComptime(
 const MainArgs = clap.ResultEx(clap.Help, &main_params, main_parsers);
 
 pub fn main(init: std.process.Init) !void {
-    var gpa_state = std.heap.DebugAllocator(.{}){};
-    const gpa = gpa_state.allocator();
-    defer _ = gpa_state.deinit();
-
-    var threaded: std.Io.Threaded = .init_single_threaded;
-    const io: std.Io = threaded.io();
-
-    var iter = try init.minimal.args.iterateAllocator(gpa);
+    var iter = try init.minimal.args.iterateAllocator(init.gpa);
     defer iter.deinit();
 
     _ = iter.next();
@@ -214,7 +193,7 @@ pub fn main(init: std.process.Init) !void {
     var diag = clap.Diagnostic{};
     var res = clap.parseEx(clap.Help, &main_params, main_parsers, &iter, .{
         .diagnostic = &diag,
-        .allocator = gpa,
+        .allocator = init.gpa,
 
         // Terminate the parsing of arguments after parsing the first positional (0 is passed
         // here because parsed positionals are, like slices and arrays, indexed starting at 0).
@@ -223,7 +202,7 @@ pub fn main(init: std.process.Init) !void {
         // not fully consumed. It can then be reused to parse the arguments for subcommands.
         .terminating_positional = 0,
     }) catch |err| {
-        try diag.reportToFile(io, .stderr(), err);
+        try diag.reportToFile(init.io, .stderr(), err);
         return err;
     };
     defer res.deinit();
@@ -234,7 +213,7 @@ pub fn main(init: std.process.Init) !void {
     const command = res.positionals[0] orelse return error.MissingCommand;
     switch (command) {
         .help => std.debug.print("--help\n", .{}),
-        .math => try mathMain(io, gpa, &iter, res),
+        .math => try mathMain(init.io, init.gpa, &iter, res),
     }
 }
 
@@ -285,13 +264,6 @@ The `streaming.Clap` is the base of all the other parsers. It's a streaming pars
 
 ```zig
 pub fn main(init: std.process.Init) !void {
-    var gpa_state = std.heap.DebugAllocator(.{}){};
-    const gpa = gpa_state.allocator();
-    defer _ = gpa_state.deinit();
-
-    var threaded: std.Io.Threaded = .init_single_threaded;
-    const io: std.Io = threaded.io();
-
     // First we specify what parameters our program can take.
     const params = [_]clap.Param(u8){
         .{
@@ -306,7 +278,7 @@ pub fn main(init: std.process.Init) !void {
         .{ .id = 'f', .takes_value = .one },
     };
 
-    var iter = try init.minimal.args.iterateAllocator(gpa);
+    var iter = try init.minimal.args.iterateAllocator(init.gpa);
     defer iter.deinit();
 
     // Skip exe argument.
@@ -325,7 +297,7 @@ pub fn main(init: std.process.Init) !void {
     // Because we use a streaming parser, we have to consume each argument parsed individually.
     while (parser.next() catch |err| {
         // Report useful error and exit.
-        try diag.reportToFile(io, .stderr(), err);
+        try diag.reportToFile(init.io, .stderr(), err);
         return err;
     }) |arg| {
         // arg.param will point to the parameter which matched the argument.
@@ -364,20 +336,13 @@ is passed to `help` to control how the help message is printed.
 
 ```zig
 pub fn main(init: std.process.Init) !void {
-    var gpa_state = std.heap.DebugAllocator(.{}){};
-    const gpa = gpa_state.allocator();
-    defer _ = gpa_state.deinit();
-
-    var threaded: std.Io.Threaded = .init_single_threaded;
-    const io: std.Io = threaded.io();
-
     const params = comptime clap.parseParamsComptime(
         \\-h, --help     Display this help and exit.
         \\-v, --version  Output version information and exit.
         \\
     );
 
-    var res = try clap.parse(clap.Help, &params, clap.parsers.default, init.minimal.args, .{ .allocator = gpa });
+    var res = try clap.parse(clap.Help, &params, clap.parsers.default, init.minimal.args, .{ .allocator = init.gpa });
     defer res.deinit();
 
     // `clap.help` is a function that can print a simple help message. It can print any `Param`
@@ -385,7 +350,7 @@ pub fn main(init: std.process.Init) !void {
     // The last argument contains options as to how `help` should print those parameters. Using
     // `.{}` means the default options.
     if (res.args.help != 0)
-        return clap.helpToFile(io, .stderr(), clap.Help, &params, .{});
+        return clap.helpToFile(init.io, .stderr(), clap.Help, &params, .{});
 }
 
 const clap = @import("clap");
@@ -408,13 +373,6 @@ $ zig-out/bin/help --help
 
 ```zig
 pub fn main(init: std.process.Init) !void {
-    var gpa_state = std.heap.DebugAllocator(.{}){};
-    const gpa = gpa_state.allocator();
-    defer _ = gpa_state.deinit();
-
-    var threaded: std.Io.Threaded = .init_single_threaded;
-    const io: std.Io = threaded.io();
-
     const params = comptime clap.parseParamsComptime(
         \\-h, --help         Display this help and exit.
         \\-v, --version      Output version information and exit.
@@ -422,13 +380,13 @@ pub fn main(init: std.process.Init) !void {
         \\
     );
 
-    var res = try clap.parse(clap.Help, &params, clap.parsers.default, init.minimal.args, .{ .allocator = gpa });
+    var res = try clap.parse(clap.Help, &params, clap.parsers.default, init.minimal.args, .{ .allocator = init.gpa });
     defer res.deinit();
 
     // `clap.usageToFile` is a function that can print a simple usage string. It can print any
     // `Param` where `Id` has a `value` method (`Param(Help)` is one such parameter).
     if (res.args.help != 0)
-        return clap.usageToFile(io, .stdout(), clap.Help, &params);
+        return clap.usageToFile(init.io, .stdout(), clap.Help, &params);
 }
 
 const clap = @import("clap");

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .name = .clap,
     .version = "0.11.0",
-    .minimum_zig_version = "0.16.0-dev.1859+212968c57",
+    .minimum_zig_version = "0.16.0-dev.2261+d6b3dd25a",
     .fingerprint = 0x65f99e6f07a316a0,
     .paths = .{
         "clap",

--- a/clap.zig
+++ b/clap.zig
@@ -648,16 +648,17 @@ pub fn parse(
     comptime Id: type,
     comptime params: []const Param(Id),
     comptime value_parsers: anytype,
+    arguments: std.process.Args,
     opt: ParseOptions,
 ) !Result(Id, params, value_parsers) {
     var arena = std.heap.ArenaAllocator.init(opt.allocator);
     errdefer arena.deinit();
 
-    var iter = try std.process.ArgIterator.initWithAllocator(arena.allocator());
+    var iter = try arguments.iterateAllocator(arena.allocator());
     const exe_arg = iter.next();
 
     const result = try parseEx(Id, params, value_parsers, &iter, .{
-        // Let's reuse the arena from the `ArgIterator` since we already have it.
+        // Let's reuse the arena from the `Args.Iterator` since we already have it.
         .allocator = arena.allocator(),
         .diagnostic = opt.diagnostic,
         .assignment_separators = opt.assignment_separators,

--- a/example/help.zig
+++ b/example/help.zig
@@ -1,4 +1,4 @@
-pub fn main() !void {
+pub fn main(init: std.process.Init) !void {
     var gpa_state = std.heap.DebugAllocator(.{}){};
     const gpa = gpa_state.allocator();
     defer _ = gpa_state.deinit();
@@ -12,7 +12,7 @@ pub fn main() !void {
         \\
     );
 
-    var res = try clap.parse(clap.Help, &params, clap.parsers.default, .{ .allocator = gpa });
+    var res = try clap.parse(clap.Help, &params, clap.parsers.default, init.minimal.args, .{ .allocator = gpa });
     defer res.deinit();
 
     // `clap.help` is a function that can print a simple help message. It can print any `Param`

--- a/example/help.zig
+++ b/example/help.zig
@@ -1,18 +1,11 @@
 pub fn main(init: std.process.Init) !void {
-    var gpa_state = std.heap.DebugAllocator(.{}){};
-    const gpa = gpa_state.allocator();
-    defer _ = gpa_state.deinit();
-
-    var threaded: std.Io.Threaded = .init_single_threaded;
-    const io: std.Io = threaded.io();
-
     const params = comptime clap.parseParamsComptime(
         \\-h, --help     Display this help and exit.
         \\-v, --version  Output version information and exit.
         \\
     );
 
-    var res = try clap.parse(clap.Help, &params, clap.parsers.default, init.minimal.args, .{ .allocator = gpa });
+    var res = try clap.parse(clap.Help, &params, clap.parsers.default, init.minimal.args, .{ .allocator = init.gpa });
     defer res.deinit();
 
     // `clap.help` is a function that can print a simple help message. It can print any `Param`
@@ -20,7 +13,7 @@ pub fn main(init: std.process.Init) !void {
     // The last argument contains options as to how `help` should print those parameters. Using
     // `.{}` means the default options.
     if (res.args.help != 0)
-        return clap.helpToFile(io, .stderr(), clap.Help, &params, .{});
+        return clap.helpToFile(init.io, .stderr(), clap.Help, &params, .{});
 }
 
 const clap = @import("clap");

--- a/example/simple-ex.zig
+++ b/example/simple-ex.zig
@@ -1,11 +1,4 @@
 pub fn main(init: std.process.Init) !void {
-    var gpa_state = std.heap.DebugAllocator(.{}){};
-    const gpa = gpa_state.allocator();
-    defer _ = gpa_state.deinit();
-
-    var threaded: std.Io.Threaded = .init_single_threaded;
-    const io: std.Io = threaded.io();
-
     // First we specify what parameters our program can take.
     // We can use `parseParamsComptime` to parse a string into an array of `Param(Help)`.
     const params = comptime clap.parseParamsComptime(
@@ -30,13 +23,13 @@ pub fn main(init: std.process.Init) !void {
     var diag = clap.Diagnostic{};
     var res = clap.parse(clap.Help, &params, parsers, init.minimal.args, .{
         .diagnostic = &diag,
-        .allocator = gpa,
+        .allocator = init.gpa,
         // The assignment separator can be configured. `--number=1` and `--number:1` is now
         // allowed.
         .assignment_separators = "=:",
     }) catch |err| {
         // Report useful error and exit.
-        try diag.reportToFile(io, .stderr(), err);
+        try diag.reportToFile(init.io, .stderr(), err);
         return err;
     };
     defer res.deinit();

--- a/example/simple-ex.zig
+++ b/example/simple-ex.zig
@@ -1,4 +1,4 @@
-pub fn main() !void {
+pub fn main(init: std.process.Init) !void {
     var gpa_state = std.heap.DebugAllocator(.{}){};
     const gpa = gpa_state.allocator();
     defer _ = gpa_state.deinit();
@@ -28,7 +28,7 @@ pub fn main() !void {
     };
 
     var diag = clap.Diagnostic{};
-    var res = clap.parse(clap.Help, &params, parsers, .{
+    var res = clap.parse(clap.Help, &params, parsers, init.minimal.args, .{
         .diagnostic = &diag,
         .allocator = gpa,
         // The assignment separator can be configured. `--number=1` and `--number:1` is now

--- a/example/simple.zig
+++ b/example/simple.zig
@@ -1,4 +1,4 @@
-pub fn main() !void {
+pub fn main(init: std.process.Init) !void {
     var gpa_state = std.heap.DebugAllocator(.{}){};
     const gpa = gpa_state.allocator();
     defer _ = gpa_state.deinit();
@@ -20,7 +20,7 @@ pub fn main() !void {
     // This is optional. You can also pass `.{}` to `clap.parse` if you don't
     // care about the extra information `Diagnostics` provides.
     var diag = clap.Diagnostic{};
-    var res = clap.parse(clap.Help, &params, clap.parsers.default, .{
+    var res = clap.parse(clap.Help, &params, clap.parsers.default, init.minimal.args, .{
         .diagnostic = &diag,
         .allocator = gpa,
     }) catch |err| {

--- a/example/simple.zig
+++ b/example/simple.zig
@@ -1,11 +1,4 @@
 pub fn main(init: std.process.Init) !void {
-    var gpa_state = std.heap.DebugAllocator(.{}){};
-    const gpa = gpa_state.allocator();
-    defer _ = gpa_state.deinit();
-
-    var threaded: std.Io.Threaded = .init_single_threaded;
-    const io: std.Io = threaded.io();
-
     // First we specify what parameters our program can take.
     // We can use `parseParamsComptime` to parse a string into an array of `Param(Help)`.
     const params = comptime clap.parseParamsComptime(
@@ -22,10 +15,10 @@ pub fn main(init: std.process.Init) !void {
     var diag = clap.Diagnostic{};
     var res = clap.parse(clap.Help, &params, clap.parsers.default, init.minimal.args, .{
         .diagnostic = &diag,
-        .allocator = gpa,
+        .allocator = init.gpa,
     }) catch |err| {
         // Report useful error and exit.
-        try diag.reportToFile(io, .stderr(), err);
+        try diag.reportToFile(init.io, .stderr(), err);
         return err;
     };
     defer res.deinit();

--- a/example/streaming-clap.zig
+++ b/example/streaming-clap.zig
@@ -1,11 +1,4 @@
 pub fn main(init: std.process.Init) !void {
-    var gpa_state = std.heap.DebugAllocator(.{}){};
-    const gpa = gpa_state.allocator();
-    defer _ = gpa_state.deinit();
-
-    var threaded: std.Io.Threaded = .init_single_threaded;
-    const io: std.Io = threaded.io();
-
     // First we specify what parameters our program can take.
     const params = [_]clap.Param(u8){
         .{
@@ -20,7 +13,7 @@ pub fn main(init: std.process.Init) !void {
         .{ .id = 'f', .takes_value = .one },
     };
 
-    var iter = try init.minimal.args.iterateAllocator(gpa);
+    var iter = try init.minimal.args.iterateAllocator(init.gpa);
     defer iter.deinit();
 
     // Skip exe argument.
@@ -39,7 +32,7 @@ pub fn main(init: std.process.Init) !void {
     // Because we use a streaming parser, we have to consume each argument parsed individually.
     while (parser.next() catch |err| {
         // Report useful error and exit.
-        try diag.reportToFile(io, .stderr(), err);
+        try diag.reportToFile(init.io, .stderr(), err);
         return err;
     }) |arg| {
         // arg.param will point to the parameter which matched the argument.

--- a/example/streaming-clap.zig
+++ b/example/streaming-clap.zig
@@ -1,4 +1,4 @@
-pub fn main() !void {
+pub fn main(init: std.process.Init) !void {
     var gpa_state = std.heap.DebugAllocator(.{}){};
     const gpa = gpa_state.allocator();
     defer _ = gpa_state.deinit();
@@ -20,7 +20,7 @@ pub fn main() !void {
         .{ .id = 'f', .takes_value = .one },
     };
 
-    var iter = try std.process.ArgIterator.initWithAllocator(gpa);
+    var iter = try init.minimal.args.iterateAllocator(gpa);
     defer iter.deinit();
 
     // Skip exe argument.
@@ -30,7 +30,7 @@ pub fn main() !void {
     // This is optional. You can also leave the `diagnostic` field unset if you
     // don't care about the extra information `Diagnostic` provides.
     var diag = clap.Diagnostic{};
-    var parser = clap.streaming.Clap(u8, std.process.ArgIterator){
+    var parser = clap.streaming.Clap(u8, std.process.Args.Iterator){
         .params = &params,
         .iter = &iter,
         .diagnostic = &diag,

--- a/example/subcommands.zig
+++ b/example/subcommands.zig
@@ -19,7 +19,7 @@ const main_params = clap.parseParamsComptime(
 // get the return type of `clap.parse` and `clap.parseEx`.
 const MainArgs = clap.ResultEx(clap.Help, &main_params, main_parsers);
 
-pub fn main() !void {
+pub fn main(init: std.process.Init) !void {
     var gpa_state = std.heap.DebugAllocator(.{}){};
     const gpa = gpa_state.allocator();
     defer _ = gpa_state.deinit();
@@ -27,7 +27,7 @@ pub fn main() !void {
     var threaded: std.Io.Threaded = .init_single_threaded;
     const io: std.Io = threaded.io();
 
-    var iter = try std.process.ArgIterator.initWithAllocator(gpa);
+    var iter = try init.minimal.args.iterateAllocator(gpa);
     defer iter.deinit();
 
     _ = iter.next();
@@ -59,7 +59,7 @@ pub fn main() !void {
     }
 }
 
-fn mathMain(io: std.Io, gpa: std.mem.Allocator, iter: *std.process.ArgIterator, main_args: MainArgs) !void {
+fn mathMain(io: std.Io, gpa: std.mem.Allocator, iter: *std.process.Args.Iterator, main_args: MainArgs) !void {
     // The parent arguments are not used here, but there are cases where it might be useful, so
     // this example shows how to pass the arguments around.
     _ = main_args;

--- a/example/usage.zig
+++ b/example/usage.zig
@@ -1,4 +1,4 @@
-pub fn main() !void {
+pub fn main(init: std.process.Init) !void {
     var gpa_state = std.heap.DebugAllocator(.{}){};
     const gpa = gpa_state.allocator();
     defer _ = gpa_state.deinit();
@@ -13,7 +13,7 @@ pub fn main() !void {
         \\
     );
 
-    var res = try clap.parse(clap.Help, &params, clap.parsers.default, .{ .allocator = gpa });
+    var res = try clap.parse(clap.Help, &params, clap.parsers.default, init.minimal.args, .{ .allocator = gpa });
     defer res.deinit();
 
     // `clap.usageToFile` is a function that can print a simple usage string. It can print any

--- a/example/usage.zig
+++ b/example/usage.zig
@@ -1,11 +1,4 @@
 pub fn main(init: std.process.Init) !void {
-    var gpa_state = std.heap.DebugAllocator(.{}){};
-    const gpa = gpa_state.allocator();
-    defer _ = gpa_state.deinit();
-
-    var threaded: std.Io.Threaded = .init_single_threaded;
-    const io: std.Io = threaded.io();
-
     const params = comptime clap.parseParamsComptime(
         \\-h, --help         Display this help and exit.
         \\-v, --version      Output version information and exit.
@@ -13,13 +6,13 @@ pub fn main(init: std.process.Init) !void {
         \\
     );
 
-    var res = try clap.parse(clap.Help, &params, clap.parsers.default, init.minimal.args, .{ .allocator = gpa });
+    var res = try clap.parse(clap.Help, &params, clap.parsers.default, init.minimal.args, .{ .allocator = init.gpa });
     defer res.deinit();
 
     // `clap.usageToFile` is a function that can print a simple usage string. It can print any
     // `Param` where `Id` has a `value` method (`Param(Help)` is one such parameter).
     if (res.args.help != 0)
-        return clap.usageToFile(io, .stdout(), clap.Help, &params);
+        return clap.usageToFile(init.io, .stdout(), clap.Help, &params);
 }
 
 const clap = @import("clap");


### PR DESCRIPTION
## Summary

- Add `arguments` parameter to `clap.parse`. Users can supply a `std.process.Args` instance from `std.process.Init`.
- Update examples.

## Breaking Changes

- Change function signature of `clap.parse`.
- Update `minimum_zig_version` to `0.16.0-dev.2261+d6b3dd25a`.