### PR TITLE
fix: use ArrayListUnmanaged.empty instead of {} initializer

### DIFF
--- a/clap.zig
+++ b/clap.zig
@@ -954,7 +954,7 @@ fn initPositionals(
             .one => @as(?T, null),
             .many => switch (multi_arg_kind) {
                 .slice => @as([]const T, &[_]T{}),
-                .list => std.ArrayListUnmanaged(T){},
+                .list => std.ArrayListUnmanaged(T).empty,
             },
         };
         i += 1;


### PR DESCRIPTION
Issues: #177 

This is the latest signature of the std.array_list.Aligned function:

```zig
pub fn Aligned(comptime T: type, comptime alignment: ?mem.Alignment) type {
```

Cause the old way of creating an empty list by directly using = {} is deprecated.