### PR TITLE
Avoid string repetition expressions in tests on newer Zig

### DIFF
--- a/clap.zig
+++ b/clap.zig
@@ -1247,8 +1247,16 @@ test "overflow-safe" {
         \\-a, --aa
     );
 
+    // copy a 300 times to the stack to make sure we overflow any internal buffers if we are not careful.
+    const long_arg = comptime blk: {
+        var buf: [301]u8 = undefined;
+        buf[0] = '-';
+        @memset(buf[1..], 'a');
+        break :blk buf;
+    };
+
     var iter = args.SliceIterator{
-        .args = &(.{"-" ++ ("a" ** 300)}),
+        .args = &.{long_arg[0..]},
     };
 
     // This just needs to not crash

--- a/clap/codepoint_counting_writer.zig
+++ b/clap/codepoint_counting_writer.zig
@@ -73,7 +73,18 @@ test CodepointCountingWriter {
     var discarding = std.Io.Writer.Discarding.init(&.{});
     var counting_stream = CodepointCountingWriter.init(&discarding.writer);
 
-    const utf8_text = "blåhaj" ** 100;
+    // copy "blåhaj" 100 times into a comptime array
+    const utf8_text_arr = comptime blk: {
+        var buf: ["blåhaj".len * 100]u8 = undefined;
+        var i: usize = 0;
+        while (i < 100) : (i += 1) {
+            buf[i * "blåhaj".len ..][0.."blåhaj".len].* = "blåhaj".*;
+        }
+        break :blk buf;
+    };
+    // array to slice
+    const utf8_text = utf8_text_arr[0..];
+
     counting_stream.interface.writeAll(utf8_text) catch unreachable;
     const expected_count = try std.unicode.utf8CountCodepoints(utf8_text);
     try testing.expectEqual(expected_count, counting_stream.codepoints_written);


### PR DESCRIPTION
This updates two tests that use `**` string repetition:
- clap.zig test "overflow-safe"
- clap/codepoint_counting_writer.zig test CodepointCountingWriter

Newer Zig dev builds reject those expressions during compilation. This change keeps the test intent the same, but builds the input strings explicitly at comptime instead of relying on **.
No runtime behavior changes. This only affects test code.

Close: #180 